### PR TITLE
Fix recurrent updates

### DIFF
--- a/contrib/update/update.yml
+++ b/contrib/update/update.yml
@@ -42,6 +42,10 @@
         update_cache: yes
         upgrade: yes
         autoremove: yes
+      register: update_upgrade
+      until: update_upgrade is not failed
+      retries: 5
+      delay: 5
 
     - name: install git and pip
       apt:

--- a/contrib/update/update.yml
+++ b/contrib/update/update.yml
@@ -14,10 +14,10 @@
       digital_ocean:
         state: active
         command: droplet
-        image_id: ubuntu-18-04-x64
+        image_id: ubuntu-20-04-x64
         name: serenata-update
         region_id: nyc1
-        size_id: s-8vcpu-32gb
+        size_id: s-16vcpu-32gb
         unique_name: yes
         ssh_key_ids:
           - "{{ ssh_public_key.ssh_key.id | int }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ djangorestframework==3.9.1
 freezegun==0.3.11
 gunicorn==19.9.0
 newrelic==4.14.0.115
-psycopg2-binary==2.7.7
+psycopg2-binary==2.8.4
 python-decouple==3.1
 python-memcached==1.59
 python-twitter==3.5


### PR DESCRIPTION
The project was having problems with the provisioned droplet. One of them was that Digital Ocean doesn't allow Ubuntu 18 anymore. That needed to change and with that a bunch of other things also needed to change (mainly due to Python 3.8 being the default now).

The other was the size of the droplet which isn't enough anymore to run the updates due to RAM size.
